### PR TITLE
Fix typo on ADR-0000 link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,5 @@ is available at https://adr.github.io/_.
 
 Architectural decisions
 
-* [ADR-0000](docs/adr/0000-use-markdown-architectural-decision-records.md>) - Use Markdown Architectural Decision Records
+* [ADR-0000](docs/adr/0000-use-markdown-architectural-decision-records.md) - Use Markdown Architectural Decision Records
 * [ADR-0001](docs/adr/0001-use-gpl3-as-license.md) - Use GNU GPL as license 


### PR DESCRIPTION
Small typo at the end of `docs/adr/0000-use-markdown-architectural-decision-records.md>`  in the readme was causing link to redirect to 404 page. 