### PR TITLE
deprecating some adr

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -18,10 +18,10 @@ jobs:
       - uses: actions/checkout@v2
 
       # Install dependencies
-      - name: Set up Python 3.7
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.7
+          python-version: 3.10
 
       - name: Install dependencies
         run: |

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,12 +1,12 @@
 ---
 repos:
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.1.9
+    rev: v1.5.1
     hooks:
       - id: remove-tabs
 
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.3.0
+    rev: v4.4.0
     hooks:
       - id: trailing-whitespace
       - id: check-merge-conflict
@@ -18,7 +18,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/adrienverge/yamllint.git
-    rev: v1.25.0
+    rev: v1.31.0
     hooks:
       - id: yamllint
         files: \.(yaml|yml)$

--- a/OWNERS
+++ b/OWNERS
@@ -1,17 +1,8 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
 approvers:
-  - 4n4nd
-  - HumairAK
-  - tumido
   - durandom
   - goern
 
 reviewers:
-  - 4n4nd
-  - anishasthana
   - harshad16
-  - hemajv
-  - HumairAK
-  - tumido
-  - larsks

--- a/OWNERS
+++ b/OWNERS
@@ -3,6 +3,9 @@
 approvers:
   - durandom
   - goern
-
+emeritus_approvers:
+  - 4n4nd  # jun 2022
+  - HumairAK   # dec 2022
+  - tumido  # april 2023
 reviewers:
   - harshad16

--- a/adr/0012-moc-infra-cluster-deployment-methods.md
+++ b/adr/0012-moc-infra-cluster-deployment-methods.md
@@ -1,5 +1,9 @@
 # Cluster deployment methods for moc-infra cluster
 
+* Status: deprecated, no-longer-relevant
+* Deciders: goern
+* Date: 2023-04-25
+
 ## Context and Problem Statement
 
 This document suggests options for the preferred deployment method for the **moc-infra cluster** at the MOC(Mass Open Cloud). This hub cluster will be the central OpenShift cluster to manage and deploy other clusters on-demand.

--- a/adr/0018-migration-to-keycloak.md
+++ b/adr/0018-migration-to-keycloak.md
@@ -1,8 +1,8 @@
 # Authentication migration to Keycloak
 
-* Status: accepted
-* Deciders: tumido
-* Date: 2021-07-14
+* Status: deprecated, no-longer-relevant
+* Deciders: goern
+* Date: 2023-04-25
 
 Technical Story: https://github.com/orgs/operate-first/projects/24
 

--- a/adr/0021-sre-cloud-support.md
+++ b/adr/0021-sre-cloud-support.md
@@ -1,8 +1,8 @@
 # Operate First Community Cloud support process
 
-* Status: accepted
-* Deciders: durandom
-* Date: 2022-07-25
+* Status: deprecated, no-longer-relevant
+* Deciders: goern
+* Date: 2023-04-25
 
 Technical Story: https://github.com/open-services-group/scrum/issues/4
 


### PR DESCRIPTION
- deprecated ARD-0012, as MOC is no longer maintained
- deprecated ARD-0018, as Keycloak is no longer maintained
- deprecated ARD-0021, as on-call support is no longer maintained
- :arrow_up: update pre-commit plugins
- updated OWNERS
- update python version used by github action

@4n4nd
@HumairAK
@tumido
@durandom
@anishasthana
@harshad16
@hemajv
@larsks

please let me know if you are unhappy with the changes!
